### PR TITLE
Fix entrypoint of the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,12 @@ FROM runtime AS final
 ARG install_dir
 ARG user
 
+RUN ln -s $install_dir/bin/calc /etc/init
+ENTRYPOINT ["/etc/init"]
+
 COPY --from=build $install_dir $install_dir
 USER $user
-ENTRYPOINT ["$install_dir/bin/calc"]
+
 
 # test
 FROM build AS test


### PR DESCRIPTION
The image did not work because the entrypoint was set wrong.
By design, Docker does not substitute any `ARG`s on `ENTRYPOINT`.