### PR TITLE
Make publish-image accept secrets

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,8 +1,15 @@
 name: publish image
 on:
   workflow_call:
-env:
-  registry: ghcr.io
+    secrets:
+      registry:
+        required: true
+      repository:
+        required: true
+      username:
+        required: true
+      password:
+        required: true
 jobs:
   job:
     runs-on: ubuntu-latest
@@ -12,14 +19,14 @@ jobs:
       - name: login to the registry
         uses: docker/login-action@v1
         with:
-          registry: ${{env.registry}}
-          username: ${{github.actor}}
-          password: ${{secrets.GITHUB_TOKEN}}
+          registry: ${{secrets.registry}}
+          username: ${{secrets.username}}
+          password: ${{secrets.password}}
       - name: extract metadata for docker
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{env.registry}}/${{github.repository}}
+          images: ${{secrets.registry}}/${{secrets.repository}}
           tags: |
             type=semver,pattern={{version}}
             type=schedule,pattern=nightly

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,3 +8,8 @@ on:
 jobs:
   publish-image:
     uses: ./.github/workflows/publish-image.yml
+    secrets:
+      registry: ghcr.io
+      repository: ${{github.repository}}
+      username: ${{github.repository_owner}}
+      password: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Now workflow `publish-image` can accept secrets from the caller, which makes it easy to change the destination of the publish.